### PR TITLE
使い方ページを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.22.0)
       msgpack (~> 1.2)
-    brakeman (8.0.2)
+    brakeman (8.0.4)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -376,7 +376,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.22.0) sha256=5820c9d42c2efef095bee6565484bdc511f1223bf950140449c9385ae775793e
-  brakeman (8.0.2) sha256=7b02065ce8b1de93949cefd3f2ad78e8eb370e644b95c8556a32a912a782426a
+  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -335,3 +335,117 @@
 .lp__card { border: 1px solid var(--border); border-radius: 12px; padding: 14px; background: var(--bg); }
 .lp__card h2 { font-size: 16px; margin: 0 0 6px; }
 .lp__card p { margin: 0; color: var(--muted); }
+
+/* guideページ用 */
+.guide {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 0 56px;
+}
+
+.guide__hero {
+  background: #f8f8f8;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  padding: 32px 24px;
+  margin-bottom: 40px;
+}
+
+.guide__title {
+  font-size: 32px;
+  margin: 0 0 16px;
+}
+
+.guide__lead {
+  margin: 0 0 12px;
+  line-height: 1.8;
+}
+
+.guide__section {
+  margin-bottom: 40px;
+}
+
+.guide__heading {
+  font-size: 24px;
+  margin: 0 0 20px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e5e5e5;
+}
+
+.guide__steps {
+  display: grid;
+  gap: 20px;
+}
+
+.guide__card {
+  position: relative;
+  background: #ffffff;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.guide__step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  font-weight: bold;
+  margin-bottom: 12px;
+  background: #222;
+  color: #fff;
+}
+
+.guide__card-title {
+  font-size: 20px;
+  margin: 0 0 12px;
+}
+
+.guide__text {
+  margin: 0 0 12px;
+  line-height: 1.8;
+}
+
+.guide__text--strong {
+  font-weight: bold;
+}
+
+.guide__feature-box {
+  background: #fafafa;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.guide__list {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+}
+
+@media (max-width: 768px) {
+  .guide {
+    padding: 24px 0 40px;
+  }
+
+  .guide__hero,
+  .guide__card,
+  .guide__feature-box {
+    padding: 20px;
+  }
+
+  .guide__title {
+    font-size: 28px;
+  }
+
+  .guide__heading {
+    font-size: 22px;
+  }
+
+  .guide__card-title {
+    font-size: 18px;
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,4 +10,6 @@ class PagesController < ApplicationController
   def terms; end
 
   def privacy; end
+
+  def guide; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,16 +28,19 @@
           <%= link_to "DrinkStock", root_path, class: "header__logo" %>
         </div>
 
-        <% if user_signed_in? %>
-          <nav class="header__nav">
+        <nav class="header__nav">
+          <% if user_signed_in? %>
             <%= link_to "在庫一覧", drinks_path, class: "nav__link" %>
+            <%= link_to "使い方", guide_path, class: "nav__link" %> <!-- ←ここに追加 -->
             <%= link_to "アカウント", account_path, class: "nav__link" %>
             <%= link_to "ログアウト",
-                        destroy_user_session_path,
-                        data: { turbo_method: :delete },
-                        class: "nav__link nav__link--danger" %>
-          </nav>
-        <% end %>
+                                   destroy_user_session_path,
+                                   data: { turbo_method: :delete },
+                                   class: "nav__link nav__link--danger" %>
+          <% else %>
+             <%= link_to "使い方", guide_path, class: "nav__link" %>
+            <% end %>
+        </nav>
       </div>
     </header>
 

--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -1,0 +1,79 @@
+<div class="guide">
+  <section class="guide__hero">
+    <h1 class="guide__title">使い方</h1>
+    <p class="guide__lead">
+      DrinkStockは、自宅にあるお酒の在庫を管理し、
+      飲酒記録を簡単に残せる個人向けアプリです。
+    </p>
+    <p class="guide__lead">
+      在庫管理と飲酒記録を連動させることで、
+      「何をどれだけ飲んだか」「今どれくらい残っているか」を
+      手間なく把握できます。
+    </p>
+  </section>
+
+  <section class="guide__section">
+    <h2 class="guide__heading">基本の使い方</h2>
+
+    <div class="guide__steps">
+      <article class="guide__card">
+        <span class="guide__step-number">1</span>
+        <h3 class="guide__card-title">お酒を登録する</h3>
+        <p class="guide__text">
+          まずは自宅にあるお酒を登録します。
+          名前・種類・本数などを入力してください。
+        </p>
+      </article>
+
+      <article class="guide__card">
+        <span class="guide__step-number">2</span>
+        <h3 class="guide__card-title">飲んだら記録する</h3>
+        <p class="guide__text">
+          飲んだお酒と量を記録します。
+        </p>
+        <p class="guide__text guide__text--strong">
+          記録を行うと、自動で在庫が減少します。
+        </p>
+        <p class="guide__text">
+          手動で在庫を調整する必要がないため、
+          日々の管理を簡単に行うことができます。
+        </p>
+      </article>
+
+      <article class="guide__card">
+        <span class="guide__step-number">3</span>
+        <h3 class="guide__card-title">今日のお酒を選ぶ</h3>
+        <p class="guide__text">
+          記録データや在庫状況をもとに、
+          今日飲むお酒の提案を確認できます。
+        </p>
+        <ul class="guide__list">
+          <li>最近飲んでいないお酒</li>
+          <li>在庫が多いお酒</li>
+        </ul>
+      </article>
+    </div>
+  </section>
+
+  <section class="guide__section">
+    <h2 class="guide__heading">このアプリの特徴</h2>
+    <div class="guide__feature-box">
+      <ul class="guide__list">
+        <li>在庫管理と飲酒記録が自動で連動する</li>
+        <li>何を飲むか迷いにくくなる</li>
+        <li>自分の飲酒傾向を振り返ることができる</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="guide__section">
+    <h2 class="guide__heading">こんな方におすすめ</h2>
+    <div class="guide__feature-box">
+      <ul class="guide__list">
+        <li>家にお酒が増えがちな方</li>
+        <li>何を飲むか毎回迷ってしまう方</li>
+        <li>飲酒量を把握したい方</li>
+      </ul>
+    </div>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get "account", to: "pages#account"
   get "terms",   to: "pages#terms"
   get "privacy", to: "pages#privacy"
+  get 'guide', to: 'pages#guide'
   devise_for :users
   resources :drinks do
     resources :drink_records, only: %i[new create edit update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get "account", to: "pages#account"
   get "terms",   to: "pages#terms"
   get "privacy", to: "pages#privacy"
-  get 'guide', to: 'pages#guide'
+  get "guide", to: "pages#guide"
   devise_for :users
   resources :drinks do
     resources :drink_records, only: %i[new create edit update destroy]


### PR DESCRIPTION
## 概要
使い方ページを追加しました。

## 変更内容
- /guide ページを追加
- PagesController に guide アクションを追加
- ヘッダーに使い方への導線を追加
- guideページのUIを調整

## 確認項目
- /guide でページが表示されること
- ヘッダーから使い方ページへ遷移できること
- ログイン前後で表示崩れがないこと