### PR TITLE
本番環境のmailer hostを設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,10 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: "drink-stock.onrender.com",
+    protocol: "https"
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 概要
本番環境でパスワードリセットメール送信時に発生していたURL生成エラーを修正しました。

## 変更内容
- production環境のaction_mailerにdefault_url_optionsを追加
- 本番環境でパスワードリセットメール内のURLが生成できるように設定

## 修正内容
```ruby
config.action_mailer.default_url_options = {
  host: "drink-stock.onrender.com",
  protocol: "https"
}