### PR TITLE
本番メール送信設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,18 @@ Rails.application.configure do
     host: "drink-stock.onrender.com",
     protocol: "https"
   }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    address: ENV["SMTP_ADDRESS"],
+    port: ENV["SMTP_PORT"],
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = "onboarding@resend.dev"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要
本番環境でパスワードリセットメールを送信できるように、メール送信設定を追加しました。

## 変更内容
- production環境のaction_mailerにSMTP設定を追加
- 本番環境でメール本文のURLを生成できるようにdefault_url_optionsを設定
- Deviseの送信元メールアドレスを設定

## 修正内容
### production.rb
- `config.action_mailer.default_url_options` を追加
- `config.action_mailer.delivery_method = :smtp` を追加
- `config.action_mailer.smtp_settings` を追加

### devise.rb
- `config.mailer_sender` を `onboarding@resend.dev` に変更

## 背景
本番環境でパスワード再設定メール送信時に、以下の問題が発生していました。

- `Missing host to link to!`
- `Connection refused - connect(2) for "localhost" port 25`

今回の修正で、
- メール本文内URLの生成に必要なhost設定
- Resend SMTPを使った本番メール送信設定

を追加しています。

## 確認項目
- 本番環境でパスワードリセット送信時に500エラーにならないこと
- 本番環境でパスワードリセットメールが送信できること
- メール内リンクからパスワード再設定画面に遷移できること

## 補足
RenderのEnvironmentには以下を設定済みです。

- `SMTP_ADDRESS`
- `SMTP_PORT`
- `SMTP_USERNAME`
- `SMTP_PASSWORD`