### PR TITLE
認証画面のUIを統一

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,28 @@
-<h2>パスワード再設定</h2>
+<h1>パスワード再設定</h1>
+<p class="muted">新しいパスワードを入力してください。</p>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div class="form">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <p><%= f.label :password, "新しいパスワード" %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %>文字以上)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :password, "新しいパスワード", class: "field__label" %>
+      <% if @minimum_password_length %>
+        <p class="muted">（<%= @minimum_password_length %>文字以上）</p>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "field__input" %>
+    </div>
 
-  <div class="field">
-    <p><%= f.label :password_confirmation, "新しいパスワード（確認用）" %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "field__label" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "field__input" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "パスワードを変更する" %>
-  </div>
-<% end %>
+    <div class="actions">
+      <%= f.submit "パスワードを変更する", class: "btn btn--primary" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <p><%= link_to "ログイン画面へ戻る", new_session_path(resource_name) %></p>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,19 @@
-<h2>パスワードをお忘れですか？</h2>
+<h1>パスワードをお忘れですか？</h1>
+<p class="muted">登録しているメールアドレス宛に、パスワード再設定用のメールを送信します。</p>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="form">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <p><%= f.label :email, "メールアドレス" %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :email, "メールアドレス", class: "field__label" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "field__input" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "パスワード再設定メールを送信する" %>
-  </div>
-<% end %>
+    <div class="actions">
+      <%= f.submit "パスワード再設定メールを送信する", class: "btn btn--primary" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <p><%= link_to "ログイン画面へ戻る", new_session_path(resource_name) %></p>
+</div>


### PR DESCRIPTION
## 概要
認証画面のUIを統一しました。

## 変更内容
- ログイン画面のUIを調整
- 新規登録画面のUIを調整
- パスワード再設定メール送信画面のUIを調整
- パスワード再設定画面のUIを調整
- 見出し、説明文、フォーム、ボタンのデザインを統一

## 確認項目
- ログイン画面の見た目が整っていること
- 新規登録画面の見た目が整っていること
- パスワード再設定メール送信画面の見た目が整っていること
- パスワード再設定画面の見た目が整っていること