### PR TITLE
在庫一覧をカード風に改善

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -600,3 +600,117 @@
     grid-template-columns: 1fr;
   }
 }
+.actions--top {
+  margin-bottom: 16px;
+}
+
+.drink-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.drink-card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.drink-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.drink-card__title {
+  font-size: 22px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.drink-card__body {
+  margin-bottom: 20px;
+}
+
+.drink-card__stock {
+  font-size: 28px;
+  font-weight: bold;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.drink-card__stock.is-empty {
+  color: #b00020;
+}
+
+.drink-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge--active {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e8f7ec;
+  color: #2e7d32;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.badge--empty {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #fdecec;
+  color: #b00020;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 24px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fafafa;
+}
+
+.empty-state__title {
+  font-size: 20px;
+  margin: 0 0 8px;
+}
+
+.empty-state__text {
+  margin: 0 0 16px;
+  color: #666;
+}
+
+@media (max-width: 1024px) {
+  .drink-cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .drink-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .drink-card {
+    padding: 20px;
+  }
+
+  .drink-card__title {
+    font-size: 20px;
+  }
+
+  .drink-card__stock {
+    font-size: 24px;
+  }
+}

--- a/app/views/drinks/index.html.erb
+++ b/app/views/drinks/index.html.erb
@@ -1,48 +1,53 @@
 <h1>在庫一覧</h1>
+<p class="muted">登録しているお酒の在庫を確認できます。</p>
 
-<div class="actions">
+<div class="actions actions--top">
   <%= link_to "＋ お酒を登録する", new_drink_path, class: "btn btn--primary" %>
 </div>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>お酒</th>
-      <th>在庫(ml)</th>
-      <th>操作</th>
-    </tr>
-  </thead>
-  <tbody>
+<% if @drinks.any? %>
+  <div class="drink-cards">
     <% @drinks.each do |drink| %>
-      <tr>
-        <td class="table__name">
-          <%= drink.name %>
-        </td>
+      <div class="drink-card">
+        <div class="drink-card__header">
+          <h2 class="drink-card__title"><%= drink.name %></h2>
 
-        <td class="table__stock <%= "is-empty" if drink.stock_ml.zero? %>">
-          <%= drink.stock_ml %> ml
           <% if drink.stock_ml.zero? %>
             <span class="badge badge--empty">在庫なし</span>
+          <% else %>
+            <span class="badge badge--active">在庫あり</span>
           <% end %>
-        </td>
+        </div>
 
-        <td class="table__actions">
+        <div class="drink-card__body">
+          <p class="drink-card__stock <%= "is-empty" if drink.stock_ml.zero? %>">
+            <%= drink.stock_ml %> ml
+          </p>
+        </div>
+
+        <div class="drink-card__actions">
           <%= link_to "詳細", drink_path(drink), class: "btn btn--small" %>
           <%= link_to "編集", edit_drink_path(drink), class: "btn btn--small" %>
-
-          <%= button_to "削除",
-              drink_path(drink),
-              method: :delete,
-              data: { turbo_confirm: "削除しますか？" },
-              class: "btn btn--small btn--danger" %>
 
           <% if drink.stock_ml > 0 %>
             <%= link_to "飲んだ",
                 new_drink_drink_record_path(drink),
                 class: "btn btn--small btn--accent" %>
           <% end %>
-        </td>
-      </tr>
+
+          <%= button_to "削除",
+              drink_path(drink),
+              method: :delete,
+              data: { turbo_confirm: "削除しますか？" },
+              class: "btn btn--small btn--danger" %>
+        </div>
+      </div>
     <% end %>
-  </tbody>
-</table>
+  </div>
+<% else %>
+  <div class="empty-state">
+    <p class="empty-state__title">まだお酒が登録されていません。</p>
+    <p class="empty-state__text">まずはお酒を登録して、在庫管理を始めましょう。</p>
+    <%= link_to "＋ お酒を登録する", new_drink_path, class: "btn btn--primary" %>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
在庫一覧画面をテーブル表示からカード風のレイアウトに改善しました。

## 変更内容
- 在庫一覧をカード形式で表示するように変更
- 在庫あり / 在庫なしの状態を見やすく調整
- 操作ボタン（詳細・編集・飲んだ・削除）の配置を整理
- 空状態の表示を追加
- 一覧画面の余白や見た目を調整

## 確認項目
- 在庫一覧がカード形式で表示されること
- 在庫あり / 在庫なしが分かりやすく表示されること
- 詳細 / 編集 / 飲んだ / 削除 の各操作ができること
- お酒が未登録のときに空状態の表示が出ること
- スマホ幅でもレイアウトが崩れないこと