### PR TITLE
ユーザーネーム機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,17 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   protected
 
   def after_sign_in_path_for(resource)
     drinks_path
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,12 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def update_resource(resource, params)
+      if params[:password].blank? && params[:password_confirmation].blank?
+        params.delete(:current_password)
+        resource.update_without_password(params)
+      else
+        resource.update_with_password(params)
+      end
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,11 @@
 class User < ApplicationRecord
   has_many :drinks, dependent: :destroy
+  has_many :drink_records, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :drink_records, dependent: :destroy
+
+  validates :name, length: { maximum: 20 }, allow_blank: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,42 +1,58 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h1>アカウント編集</h1>
+<p class="muted">ユーザー情報やパスワードを変更できます。</p>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="form">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :name, "ユーザーネーム", class: "field__label" %>
+      <%= f.text_field :name, autofocus: true, class: "field__input", placeholder: "例: 晩酌びより" %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+    <div class="field">
+      <%= f.label :email, "メールアドレス", class: "field__label" %>
+      <%= f.email_field :email, autocomplete: "email", class: "field__input" %>
+    </div>
 
-  <div class="field">
-    <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i></p>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-    <% if @minimum_password_length %>
-      <p><em><%= @minimum_password_length %> characters minimum</em></p>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p class="help">現在確認待ちのメールアドレス: <%= resource.unconfirmed_email %></p>
     <% end %>
-  </div>
 
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :password, "新しいパスワード", class: "field__label" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "field__input" %>
+      <p class="help">変更しない場合は空欄のままで大丈夫です。</p>
+      <% if @minimum_password_length %>
+        <p class="help">※ <%= @minimum_password_length %>文字以上</p>
+      <% end %>
+    </div>
 
-  <div class="field">
-    <p><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i></p>
-    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
-  </div>
+    <div class="field">
+      <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "field__label" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "field__input" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
+    <div class="field">
+      <%= f.label :current_password, "現在のパスワード", class: "field__label" %>
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "field__input" %>
+      <p class="help">パスワードを変更する場合のみ、現在のパスワードを入力してください。</p>
+    </div>
 
-<h3>Cancel my account</h3>
+    <div class="actions">
+      <%= f.submit "更新する", class: "btn btn--primary" %>
+      <%= link_to "アカウントへ戻る", account_path, class: "btn" %>
+    </div>
+  <% end %>
+</div>
 
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<div class="form" style="margin-top: 24px;">
+  <h2>アカウント削除</h2>
+  <p class="muted">アカウントを削除すると元に戻せません。</p>
 
-<%= link_to "Back", :back %>
+  <%= button_to "アカウントを削除する",
+      registration_path(resource_name),
+      method: :delete,
+      data: { turbo_confirm: "本当に削除しますか？" },
+      class: "btn btn--danger" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,8 +14,13 @@
     <% end %>
 
     <div class="field">
+      <%= f.label :name, "ユーザーネーム", class: "field__label" %>
+      <%= f.text_field :name, autofocus: true, class: "field__input", placeholder: "例: 晩酌びより" %>
+    </div>
+
+    <div class="field">
       <%= f.label :email, class: "field__label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "field__input" %>
+      <%= f.email_field :email, autocomplete: "email", class: "field__input" %>
     </div>
 
     <div class="field">

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -1,13 +1,24 @@
 <h1>アカウント</h1>
+<p class="muted">登録しているアカウント情報を確認できます。</p>
 
 <% if user_signed_in? %>
-  <p>ログイン中: <%= current_user.email %></p>
-  <%#= button_to "ログアウト", destroy_user_session_path, method: :delete %>
+  <div class="form">
+    <div class="field">
+      <div class="field__label">ユーザーネーム</div>
+      <p><%= current_user.name.presence || "未設定" %></p>
+    </div>
+
+    <div class="field">
+      <div class="field__label">メールアドレス</div>
+      <p><%= current_user.email %></p>
+    </div>
+
+    <div class="actions">
+      <%= link_to "アカウントを編集する", edit_user_registration_path, class: "btn btn--primary" %>
+      <%= link_to "トップへ戻る", root_path, class: "btn" %>
+    </div>
+  </div>
 <% else %>
   <p>ログインしていません</p>
-  <p><a href="/users/sign_in">ログイン</a></p>
+  <p><%= link_to "ログイン", new_user_session_path, class: "btn btn--primary" %></p>
 <% end %>
-
-<p><%= link_to "トップへ戻る", root_path, class: "btn" %></p>
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,22 +6,18 @@ Rails.application.routes.draw do
   get "terms",   to: "pages#terms"
   get "privacy", to: "pages#privacy"
   get "guide", to: "pages#guide"
-  devise_for :users
+
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
+
   resources :drinks do
     resources :drink_records, only: %i[new create edit update destroy]
   end
 
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # Defines the root path route ("/")
-  # root "posts#index"
   root to: "pages#home"
 end

--- a/db/migrate/20260527143959_add_name_to_users.rb
+++ b/db/migrate/20260527143959_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_13_114858) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_27_143959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_13_114858) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
ユーザーネーム機能を追加しました。

## 変更内容
- usersテーブルにnameカラムを追加
- 新規登録画面にユーザーネーム入力欄を追加
- アカウント編集画面にユーザーネーム入力欄を追加
- Deviseの許可パラメータにnameを追加
- アカウント画面でユーザーネームを表示するように変更
- Userモデルにユーザーネームのバリデーションを追加
- パスワード未変更時は現在のパスワードなしでアカウント情報を更新できるように修正

## 確認項目
- 新規登録時にユーザーネームを入力して保存できること
- アカウント編集画面でユーザーネームを変更できること
- ユーザーネームのみ変更する場合、現在のパスワードなしで更新できること
- アカウント画面でユーザーネームが表示されること