### PR TITLE
飲酒ログ画面を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -797,3 +797,52 @@
   flex-wrap: wrap;
   gap: 8px;
 }
+
+.log-list {
+  display: grid;
+  gap: 16px;
+}
+
+.log-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.log-card__main {
+  flex: 1;
+}
+
+.log-card__title {
+  font-size: 20px;
+  margin: 0 0 4px;
+}
+
+.log-card__amount {
+  font-size: 22px;
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.log-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .log-card {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .log-card__amount {
+    font-size: 20px;
+  }
+}

--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -1,8 +1,11 @@
 class DrinkRecordsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_drink
+  before_action :set_drink, except: :index
   before_action :set_drink_record, only: %i[edit update destroy]
 
+  def index
+    @drink_records = current_user.drink_records.includes(:drink).order(consumed_at: :desc)
+  end
 
   def new
     @drink_record = @drink.drink_records.new(consumed_at: Time.current)

--- a/app/views/drink_records/index.html.erb
+++ b/app/views/drink_records/index.html.erb
@@ -1,0 +1,39 @@
+<h1>飲酒ログ</h1>
+<p class="muted">これまでに記録した飲酒履歴を確認できます。</p>
+
+<% if @drink_records.any? %>
+  <div class="log-list">
+    <% @drink_records.each do |record| %>
+      <div class="log-card">
+        <div class="log-card__main">
+          <h2 class="log-card__title"><%= record.drink.name %></h2>
+          <p class="muted">
+            <%= l(record.consumed_at, format: :short) rescue record.consumed_at %>
+          </p>
+        </div>
+
+        <div class="log-card__amount">
+          <%= record.consumed_ml %> ml
+        </div>
+
+        <div class="log-card__actions">
+          <%= link_to "編集",
+              edit_drink_drink_record_path(record.drink, record),
+              class: "btn btn--small" %>
+
+          <%= button_to "削除",
+              drink_drink_record_path(record.drink, record),
+              method: :delete,
+              data: { turbo_confirm: "この履歴を削除しますか？" },
+              class: "btn btn--small btn--danger" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="empty-state">
+    <p class="empty-state__title">まだ飲酒ログがありません。</p>
+    <p class="empty-state__text">お酒を飲んだ記録を登録すると、ここに履歴が表示されます。</p>
+    <%= link_to "在庫一覧へ", drinks_path, class: "btn btn--primary" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,8 @@
         <nav class="header__nav">
           <% if user_signed_in? %>
             <%= link_to "在庫一覧", drinks_path, class: "nav__link" %>
-            <%= link_to "使い方", guide_path, class: "nav__link" %> <!-- ←ここに追加 -->
+            <%= link_to "飲酒ログ", drink_records_path, class: "nav__link" %>
+            <%= link_to "使い方", guide_path, class: "nav__link" %>
             <%= link_to "アカウント", account_path, class: "nav__link" %>
             <%= link_to "ログアウト",
                                    destroy_user_session_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     registrations: "users/registrations"
   }
 
+  resources :drink_records, only: %i[index]
+
   resources :drinks do
     resources :drink_records, only: %i[new create edit update destroy]
   end


### PR DESCRIPTION
## 概要
これまでに記録した飲酒履歴を一覧で確認できる、飲酒ログ画面を追加しました。

## 変更内容
- 飲酒記録一覧用のルーティングを追加
- DrinkRecordsControllerにindexアクションを追加
- 飲酒ログ画面を追加
- ヘッダーに飲酒ログへの導線を追加
- 飲酒ログをカード形式で表示
- 飲酒ログがない場合の空状態を追加

## 確認項目
- ヘッダーの「飲酒ログ」から一覧画面へ遷移できること
- 飲酒記録がカード形式で表示されること
- お酒名、飲んだ日、飲んだ量が表示されること
- 編集・削除ボタンが動作すること
- 飲酒ログがない場合に空状態が表示されること