### PR TITLE
飲酒ログの表記を飲酒履歴に変更

### DIFF
--- a/app/views/drink_records/index.html.erb
+++ b/app/views/drink_records/index.html.erb
@@ -1,5 +1,5 @@
-<h1>飲酒ログ</h1>
-<p class="muted">これまでに記録した飲酒履歴を確認できます。</p>
+<h1>飲酒履歴</h1>
+<p class="muted">これまでに記録した飲酒量や日付を確認できます。</p>
 
 <% if @drink_records.any? %>
   <div class="log-list">
@@ -32,7 +32,7 @@
   </div>
 <% else %>
   <div class="empty-state">
-    <p class="empty-state__title">まだ飲酒ログがありません。</p>
+    <p class="empty-state__title">まだ飲酒履歴がありません。</p>
     <p class="empty-state__text">お酒を飲んだ記録を登録すると、ここに履歴が表示されます。</p>
     <%= link_to "在庫一覧へ", drinks_path, class: "btn btn--primary" %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
         <nav class="header__nav">
           <% if user_signed_in? %>
             <%= link_to "在庫一覧", drinks_path, class: "nav__link" %>
-            <%= link_to "飲酒ログ", drink_records_path, class: "nav__link" %>
+            <%= link_to "飲酒履歴", drink_records_path, class: "nav__link" %>
             <%= link_to "使い方", guide_path, class: "nav__link" %>
             <%= link_to "アカウント", account_path, class: "nav__link" %>
             <%= link_to "ログアウト",


### PR DESCRIPTION
## 概要
飲酒記録一覧画面の表記を「飲酒ログ」から「飲酒履歴」に変更しました。

## 変更内容
- ヘッダーのリンク名を「飲酒履歴」に変更
- 飲酒記録一覧画面の見出しを「飲酒履歴」に変更
- 空状態の文言を「飲酒履歴」に変更

## 背景
今後追加予定の「お酒ログ」機能と意味が混同しないように、既存の飲酒記録一覧は「飲酒履歴」として表記を整理しました。

## 確認項目
- ヘッダーに「飲酒履歴」と表示されること
- 飲酒履歴画面が正しく表示されること
- 既存の編集・削除操作が問題なく動作すること