### PR TITLE
お酒ログ機能を追加

### DIFF
--- a/app/controllers/drink_logs_controller.rb
+++ b/app/controllers/drink_logs_controller.rb
@@ -1,0 +1,56 @@
+class DrinkLogsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_drink, only: %i[new create edit update destroy]
+  before_action :set_drink_log, only: %i[edit update destroy]
+
+  def index
+    @drink_logs = current_user.drink_logs.includes(:drink).order(logged_at: :desc)
+  end
+
+  def new
+    @drink_log = current_user.drink_logs.new(logged_at: Time.current)
+    @drink_log.drink = @drink if @drink.present?
+  end
+
+  def create
+    @drink_log = current_user.drink_logs.new(drink_log_params)
+    @drink_log.drink = @drink if @drink.present?
+
+    if @drink_log.save
+      redirect_to drink_logs_path, notice: "お酒ログを登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @drink_log.update(drink_log_params)
+      redirect_to drink_logs_path, notice: "お酒ログを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @drink_log.destroy!
+    redirect_to drink_logs_path, notice: "お酒ログを削除しました"
+  end
+
+  private
+
+  def set_drink
+    @drink = current_user.drinks.find_by(id: params[:drink_id])
+  end
+
+  def set_drink_log
+    @drink_log = current_user.drink_logs.find(params[:id])
+    @drink = @drink_log.drink
+  end
+
+  def drink_log_params
+    params.require(:drink_log).permit(:drink_name, :memo, :rating, :logged_at)
+  end
+end

--- a/app/helpers/drink_logs_helper.rb
+++ b/app/helpers/drink_logs_helper.rb
@@ -1,0 +1,2 @@
+module DrinkLogsHelper
+end

--- a/app/models/drink.rb
+++ b/app/models/drink.rb
@@ -1,6 +1,7 @@
 class Drink < ApplicationRecord
   belongs_to :user
   has_many :drink_records, dependent: :destroy
+  has_many :drink_logs, dependent: :destroy
 
   before_validation :normalize_name
 

--- a/app/models/drink_log.rb
+++ b/app/models/drink_log.rb
@@ -1,0 +1,16 @@
+class DrinkLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :drink, optional: true
+
+  before_validation :set_default_logged_at
+
+  validates :memo, length: { maximum: 500 }, allow_blank: true
+  validates :rating, inclusion: { in: 1..5 }, allow_nil: true
+  validates :drink_name, presence: true, if: -> { drink.blank? }
+
+  private
+
+  def set_default_logged_at
+    self.logged_at ||= Time.current
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :drinks, dependent: :destroy
   has_many :drink_records, dependent: :destroy
+  has_many :drink_logs, dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/drink_logs/_form.html.erb
+++ b/app/views/drink_logs/_form.html.erb
@@ -1,0 +1,60 @@
+<%= form_with model: drink.present? ? [drink, drink_log] : drink_log, local: true do |f| %>
+  <% if drink_log.errors.any? %>
+    <div class="alert alert--danger">
+      <ul>
+        <% drink_log.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form form--record">
+    <% if drink.present? %>
+      <p class="muted">お酒：<strong><%= drink.name %></strong></p>
+    <% else %>
+      <div class="field">
+        <%= f.label :drink_name, "お酒の名前", class: "field__label" %>
+        <%= f.text_field :drink_name,
+            class: "field__input",
+            placeholder: "例: 山崎" %>
+        <p class="help">在庫に登録していないお酒もログとして残せます。</p>
+      </div>
+    <% end %>
+
+    <div class="field">
+  <%= f.label :memo, "メモ・感想", class: "field__label" %>
+  <%= f.text_area :memo,
+      rows: 6,
+      class: "field__input",
+      placeholder: "例: 香りがよく、食事に合わせやすかったです。" %>
+  <p class="help">空欄でも登録できます。感想やまた飲みたいかなどを自由に残せます。</p>
+</div>
+
+<div class="field">
+  <%= f.label :rating, "評価", class: "field__label" %>
+  <%= f.select :rating,
+      options_for_select((1..5).map { |n| ["★" * n, n] }, drink_log.rating),
+      { include_blank: "評価を選択" },
+      class: "field__input" %>
+  <p class="help">任意で1〜5の範囲で評価できます。</p>
+</div>
+
+    <div class="field">
+      <%= f.label :logged_at, "記録日", class: "field__label" %>
+      <div class="field__datetime">
+        <%= f.date_select :logged_at, use_month_numbers: true %>
+      </div>
+    </div>
+
+    <div class="actions actions--record">
+      <%= f.submit "保存する", class: "btn btn--accent" %>
+
+      <% if drink.present? %>
+        <%= link_to "戻る", drink_path(drink), class: "btn" %>
+      <% else %>
+        <%= link_to "戻る", drink_logs_path, class: "btn" %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/drink_logs/edit.html.erb
+++ b/app/views/drink_logs/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>お酒ログを編集</h1>
+<p class="muted">
+  お酒：<strong><%= @drink&.name || @drink_log.drink_name %></strong>
+</p>
+
+<%= render "form", drink: @drink, drink_log: @drink_log %>

--- a/app/views/drink_logs/index.html.erb
+++ b/app/views/drink_logs/index.html.erb
@@ -1,0 +1,52 @@
+<h1>お酒ログ</h1>
+<p class="muted">お酒ごとに残した感想や評価を確認できます。</p>
+
+<div class="actions actions--top">
+  <%= link_to "＋ ログを書く", new_drink_log_path, class: "btn btn--primary" %>
+</div>
+
+<% if @drink_logs.any? %>
+  <div class="log-list">
+    <% @drink_logs.each do |log| %>
+      <div class="log-card">
+        <div class="log-card__main">
+          <h2 class="log-card__title">
+            <%= log.drink&.name || log.drink_name %>
+          </h2>
+
+          <p class="muted">
+            <%= log.logged_at.strftime("%Y/%m/%d") %>
+          </p>
+
+          <% if log.rating.present? %>
+            <p class="drink-log__rating">
+              評価：<%= "★" * log.rating %>
+            </p>
+          <% end %>
+
+          <% if log.memo.present? %>
+            <div class="drink-log__memo"><%= simple_format(log.memo) %></div>
+          <% end %>
+        </div>
+
+        <div class="log-card__actions">
+          <%= link_to "編集",
+              edit_drink_log_path(log),
+              class: "btn btn--small" %>
+
+          <%= button_to "削除",
+              drink_log_path(log),
+              method: :delete,
+              data: { turbo_confirm: "このログを削除しますか？" },
+              class: "btn btn--small btn--danger" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <div class="empty-state">
+    <p class="empty-state__title">まだお酒ログがありません。</p>
+    <p class="empty-state__text">飲んだ感想や評価を残すと、ここにログが表示されます。</p>
+    <%= link_to "＋ ログを書く", new_drink_log_path, class: "btn btn--primary" %>
+  </div>
+<% end %>

--- a/app/views/drink_logs/new.html.erb
+++ b/app/views/drink_logs/new.html.erb
@@ -1,0 +1,4 @@
+<h1>お酒ログを登録</h1>
+<p class="muted">飲んだお酒の感想や評価を残せます。</p>
+
+<%= render "form", drink: @drink, drink_log: @drink_log %>

--- a/app/views/drink_records/index.html.erb
+++ b/app/views/drink_records/index.html.erb
@@ -8,7 +8,7 @@
         <div class="log-card__main">
           <h2 class="log-card__title"><%= record.drink.name %></h2>
           <p class="muted">
-            <%= l(record.consumed_at, format: :short) rescue record.consumed_at %>
+            <%= record.consumed_at.strftime("%Y/%m/%d") %>
           </p>
         </div>
 

--- a/app/views/drinks/show.html.erb
+++ b/app/views/drinks/show.html.erb
@@ -26,6 +26,10 @@
             class: "btn btn--accent" %>
       <% end %>
 
+      <%= link_to "ログを書く",
+          new_drink_drink_log_path(@drink),
+          class: "btn" %>
+
       <%= link_to "編集", edit_drink_path(@drink), class: "btn" %>
       <%= link_to "在庫一覧へ戻る", drinks_path, class: "btn" %>
       <%= button_to "削除",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
           <% if user_signed_in? %>
             <%= link_to "在庫一覧", drinks_path, class: "nav__link" %>
             <%= link_to "飲酒履歴", drink_records_path, class: "nav__link" %>
+            <%= link_to "お酒ログ", drink_logs_path, class: "nav__link" %>
             <%= link_to "使い方", guide_path, class: "nav__link" %>
             <%= link_to "アカウント", account_path, class: "nav__link" %>
             <%= link_to "ログアウト",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  get "drink_logs/index"
+  get "drink_logs/new"
+  get "drink_logs/edit"
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
   get "home", to: "pages#home"
@@ -12,9 +15,11 @@ Rails.application.routes.draw do
   }
 
   resources :drink_records, only: %i[index]
+  resources :drink_logs, only: %i[index new create edit update destroy]
 
   resources :drinks do
     resources :drink_records, only: %i[new create edit update destroy]
+    resources :drink_logs, only: %i[new create edit update destroy]
   end
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260529081211_create_drink_logs.rb
+++ b/db/migrate/20260529081211_create_drink_logs.rb
@@ -1,0 +1,13 @@
+class CreateDrinkLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :drink_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :drink, null: false, foreign_key: true
+      t.text :memo
+      t.integer :rating
+      t.datetime :logged_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260529102533_add_drink_name_to_drink_logs.rb
+++ b/db/migrate/20260529102533_add_drink_name_to_drink_logs.rb
@@ -1,0 +1,5 @@
+class AddDrinkNameToDrinkLogs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :drink_logs, :drink_name, :string
+  end
+end

--- a/db/migrate/20260529104129_change_drink_id_null_on_drink_logs.rb
+++ b/db/migrate/20260529104129_change_drink_id_null_on_drink_logs.rb
@@ -1,0 +1,5 @@
+class ChangeDrinkIdNullOnDrinkLogs < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :drink_logs, :drink_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_27_143959) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_29_104129) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "drink_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "drink_id"
+    t.text "memo"
+    t.integer "rating"
+    t.datetime "logged_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "drink_name"
+    t.index ["drink_id"], name: "index_drink_logs_on_drink_id"
+    t.index ["user_id"], name: "index_drink_logs_on_user_id"
+  end
 
   create_table "drink_records", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -47,6 +60,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_27_143959) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "drink_logs", "drinks"
+  add_foreign_key "drink_logs", "users"
   add_foreign_key "drink_records", "drinks"
   add_foreign_key "drink_records", "users"
   add_foreign_key "drinks", "users"

--- a/test/fixtures/drink_logs.yml
+++ b/test/fixtures/drink_logs.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  drink: one
+  memo: MyText
+  rating: 1
+  logged_at: 2026-05-29 17:12:11
+
+two:
+  user: two
+  drink: two
+  memo: MyText
+  rating: 1
+  logged_at: 2026-05-29 17:12:11

--- a/test/models/drink_log_test.rb
+++ b/test/models/drink_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DrinkLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
お酒ごとに感想や評価を残せる、お酒ログ機能を追加しました。

## 変更内容
- DrinkLogモデルを追加
- お酒ログの一覧・登録・編集・削除機能を追加
- 在庫に登録していないお酒もログとして登録できるように対応
- お酒ログ画面から新規登録できる導線を追加
- お酒詳細画面に「ログを書く」導線を追加
- メモ・評価を任意入力にして、気軽にログを残せるように調整

## 確認項目
- お酒ログ一覧が表示されること
- お酒ログを新規登録できること
- 在庫に登録していないお酒名でもログを登録できること
- メモなし・評価なしでも登録できること
- お酒ログを編集できること
- お酒ログを削除できること
- お酒詳細画面からログ登録画面へ遷移できること