### PR TITLE
今日のお酒提案機能を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -846,3 +846,63 @@
     font-size: 20px;
   }
 }
+
+.suggestion-card {
+  margin: 20px 0 24px;
+  padding: 24px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.suggestion-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  margin: 20px 0 24px;
+  padding: 20px 24px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fff8e8;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.suggestion-banner__content {
+  flex: 1;
+}
+
+.suggestion-banner__label {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: bold;
+  color: #8a5a00;
+}
+
+.suggestion-banner__title {
+  margin: 0 0 6px;
+  font-size: 24px;
+}
+
+.suggestion-banner__text {
+  margin: 0;
+  color: #666;
+}
+
+.suggestion-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .suggestion-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .suggestion-banner__title {
+    font-size: 22px;
+  }
+}

--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -4,6 +4,7 @@ class DrinksController < ApplicationController
 
   def index
     @drinks = current_user.drinks.order(created_at: :desc)
+    @suggested_drink = current_user.drinks.where("stock_ml > 0").order("RANDOM()").first
   end
 
   def new

--- a/app/views/drinks/index.html.erb
+++ b/app/views/drinks/index.html.erb
@@ -5,6 +5,28 @@
   <%= link_to "＋ お酒を登録する", new_drink_path, class: "btn btn--primary" %>
 </div>
 
+<% if @suggested_drink.present? %>
+  <div class="suggestion-banner">
+    <div class="suggestion-banner__content">
+      <p class="suggestion-banner__label">今日のお酒の提案</p>
+      <h2 class="suggestion-banner__title"><%= @suggested_drink.name %></h2>
+      <p class="suggestion-banner__text">
+        今日はこのお酒を飲んでみませんか？
+      </p>
+    </div>
+
+    <div class="suggestion-banner__actions">
+      <%= link_to "このお酒を飲んだ",
+          new_drink_drink_record_path(@suggested_drink),
+          class: "btn btn--accent" %>
+
+      <%= link_to "詳細を見る",
+          drink_path(@suggested_drink),
+          class: "btn" %>
+    </div>
+  </div>
+<% end %>
+
 <% if @drinks.any? %>
   <div class="drink-cards">
     <% @drinks.each do |drink| %>


### PR DESCRIPTION
## 概要
在庫があるお酒の中から、今日飲むお酒を提案する機能を追加しました。

## 変更内容
- 在庫があるお酒からランダムで1件提案する処理を追加
- 在庫一覧画面に「今日のお酒」バナーを追加
- 提案されたお酒から飲酒記録画面へ遷移できる導線を追加
- 提案されたお酒の詳細画面へ遷移できる導線を追加
- 提案バナーのデザインを調整

## 確認項目
- 在庫があるお酒が提案されること
- 在庫0のお酒は提案されないこと
- 「飲んだ」ボタンから飲酒記録画面へ遷移できること
- 「詳細」ボタンからお酒詳細画面へ遷移できること
- 在庫がない場合に提案バナーが表示されないこと