### PR TITLE
飲酒データの集計表示を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -906,3 +906,37 @@
     font-size: 22px;
   }
 }
+
+.summary-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin: 20px 0 24px;
+}
+
+.summary-card {
+  padding: 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+}
+
+.summary-card__label {
+  margin: 0 0 8px;
+  color: #666;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.summary-card__value {
+  margin: 0;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+@media (max-width: 768px) {
+  .summary-cards {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -5,6 +5,18 @@ class DrinkRecordsController < ApplicationController
 
   def index
     @drink_records = current_user.drink_records.includes(:drink).order(consumed_at: :desc)
+
+    @weekly_consumed_ml = current_user.drink_records
+      .where(consumed_at: 7.days.ago.beginning_of_day..Time.current)
+      .sum(:consumed_ml)
+
+    @monthly_record_count = current_user.drink_records
+      .where(consumed_at: 30.days.ago.beginning_of_day..Time.current)
+      .count
+
+    @monthly_consumed_ml = current_user.drink_records
+      .where(consumed_at: 30.days.ago.beginning_of_day..Time.current)
+      .sum(:consumed_ml)
   end
 
   def new
@@ -50,7 +62,7 @@ class DrinkRecordsController < ApplicationController
       new_stock = restored_stock - new_consumed
 
       if new_stock < 0
-        @drink_record.assign_attributes(drink_record_params) # 画面に入力値を残す
+        @drink_record.assign_attributes(drink_record_params)
         @drink_record.errors.add(:consumed_ml, "が在庫を超えています")
         raise ActiveRecord::RecordInvalid, @drink_record
       end
@@ -59,7 +71,7 @@ class DrinkRecordsController < ApplicationController
       @drink.update!(stock_ml: new_stock)
     end
 
-    redirect_to drink_path(@drink), notice: "飲酒記録を更新しました"
+    redirect_to after_update_drink_record_path, notice: "飲酒記録を更新しました"
   rescue ActiveRecord::RecordInvalid
     render :edit, status: :unprocessable_entity
   end
@@ -68,12 +80,11 @@ class DrinkRecordsController < ApplicationController
     ActiveRecord::Base.transaction do
       @drink.lock!
 
-      # 削除する分、在庫を戻す
       @drink.update!(stock_ml: @drink.stock_ml + @drink_record.consumed_ml)
       @drink_record.destroy!
     end
 
-    redirect_to drink_path(@drink), notice: "飲酒記録を削除しました"
+    redirect_to after_destroy_drink_record_path, notice: "飲酒記録を削除しました"
   end
 
   def normalize_consumed_at
@@ -92,5 +103,21 @@ class DrinkRecordsController < ApplicationController
 
   def drink_record_params
     params.require(:drink_record).permit(:consumed_ml, :consumed_at)
+  end
+
+  def after_update_drink_record_path
+    if params[:return_to] == "show"
+      drink_path(@drink)
+    else
+      drink_records_path
+    end
+  end
+
+  def after_destroy_drink_record_path
+    if params[:return_to] == "show"
+      drink_path(@drink)
+    else
+      drink_records_path
+    end
   end
 end

--- a/app/views/drink_records/_form.html.erb
+++ b/app/views/drink_records/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: [drink, drink_record], local: true do |f| %>
+  <%= hidden_field_tag :return_to, params[:return_to] %>
+
   <% if drink_record.errors.any? %>
     <div class="alert alert--danger">
       <ul>

--- a/app/views/drink_records/index.html.erb
+++ b/app/views/drink_records/index.html.erb
@@ -1,6 +1,23 @@
 <h1>飲酒履歴</h1>
 <p class="muted">これまでに記録した飲酒量や日付を確認できます。</p>
 
+<div class="summary-cards">
+  <div class="summary-card">
+    <p class="summary-card__label">直近7日間の飲酒量</p>
+    <p class="summary-card__value"><%= @weekly_consumed_ml %> ml</p>
+  </div>
+
+  <div class="summary-card">
+    <p class="summary-card__label">直近30日間の飲酒回数</p>
+    <p class="summary-card__value"><%= @monthly_record_count %> 回</p>
+  </div>
+
+  <div class="summary-card">
+    <p class="summary-card__label">直近30日間の飲酒量</p>
+    <p class="summary-card__value"><%= @monthly_consumed_ml %> ml</p>
+  </div>
+</div>
+
 <% if @drink_records.any? %>
   <div class="log-list">
     <% @drink_records.each do |record| %>
@@ -18,11 +35,11 @@
 
         <div class="log-card__actions">
           <%= link_to "編集",
-              edit_drink_drink_record_path(record.drink, record),
+              edit_drink_drink_record_path(record.drink, record, return_to: "index"),
               class: "btn btn--small" %>
 
           <%= button_to "削除",
-              drink_drink_record_path(record.drink, record),
+              drink_drink_record_path(record.drink, record, return_to: "index"),
               method: :delete,
               data: { turbo_confirm: "この履歴を削除しますか？" },
               class: "btn btn--small btn--danger" %>

--- a/app/views/drinks/show.html.erb
+++ b/app/views/drinks/show.html.erb
@@ -59,11 +59,11 @@
             <td class="table__actions">
               <div class="table__action-group">
                 <%= link_to "編集",
-                    edit_drink_drink_record_path(@drink, record),
+                    edit_drink_drink_record_path(@drink, record, return_to: "show"),
                     class: "btn btn--small" %>
 
                 <%= button_to "削除",
-                    drink_drink_record_path(@drink, record),
+                    drink_drink_record_path(@drink, record, return_to: "show"),
                     method: :delete,
                     data: { turbo_confirm: "この履歴を削除しますか？" },
                     class: "btn btn--small btn--danger" %>


### PR DESCRIPTION
## 概要
飲酒履歴画面に、飲酒量・飲酒頻度の集計表示を追加しました。

## 変更内容
- 直近7日間の飲酒量を表示
- 直近30日間の飲酒回数を表示
- 直近30日間の飲酒量を表示
- 飲酒履歴画面に集計カードを追加
- 飲酒記録の編集・削除後の戻り先を、遷移元に応じて切り替えるように修正

## 確認項目
- 飲酒履歴画面に集計カードが表示されること
- 直近7日間の飲酒量が表示されること
- 直近30日間の飲酒回数が表示されること
- 直近30日間の飲酒量が表示されること
- 飲酒履歴画面から編集した場合、保存後に飲酒履歴へ戻ること
- お酒詳細画面から編集した場合、保存後にお酒詳細へ戻ること
- 飲酒履歴画面から削除した場合、削除後に飲酒履歴へ戻ること
- お酒詳細画面から削除した場合、削除後にお酒詳細へ戻ること