### PR TITLE
ダッシュボードに週間飲酒量グラフを追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -986,3 +986,41 @@
   border-color: #333;
   font-weight: bold;
 }
+
+.weekly-chart {
+  display: grid;
+  gap: 12px;
+}
+
+.weekly-chart__row {
+  display: grid;
+  grid-template-columns: 48px 1fr 64px;
+  align-items: center;
+  gap: 12px;
+}
+
+.weekly-chart__label {
+  color: #666;
+  font-size: 14px;
+}
+
+.weekly-chart__bar-wrap {
+  height: 14px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #f1f1f1;
+}
+
+.weekly-chart__bar {
+  height: 100%;
+  min-width: 4px;
+  border-radius: 999px;
+  background: #8b5e3c;
+}
+
+.weekly-chart__value {
+  text-align: right;
+  color: #333;
+  font-size: 14px;
+  font-weight: 600;
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -19,5 +19,20 @@ class DashboardController < ApplicationController
       .sum(:consumed_ml)
 
     @recent_drink_logs = current_user.drink_logs.includes(:drink).order(logged_at: :desc).limit(3)
+
+    today = Time.zone.today
+    @weekly_drinking_chart = (6.days.ago.to_date..today).map do |date|
+      total_ml = current_user.drink_records
+        .where(consumed_at: date.beginning_of_day..date.end_of_day)
+        .sum(:consumed_ml)
+
+     {
+       date: date,
+       label: date.strftime("%-m/%-d"),
+       total_ml: total_ml
+     }
+    end
+
+    @weekly_max_consumed_ml = @weekly_drinking_chart.map { |data| data[:total_ml] }.max.to_i
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -98,6 +98,26 @@
 </div>
 
 <div class="dashboard-section">
+  <h2 class="section-title">直近7日間の飲酒量</h2>
+
+  <div class="weekly-chart">
+    <% @weekly_drinking_chart.each do |data| %>
+      <% bar_width = @weekly_max_consumed_ml.positive? ? (data[:total_ml].to_f / @weekly_max_consumed_ml * 100).round : 0 %>
+
+      <div class="weekly-chart__row">
+        <div class="weekly-chart__label"><%= data[:label] %></div>
+
+        <div class="weekly-chart__bar-wrap">
+          <div class="weekly-chart__bar" style="width: <%= bar_width %>%"></div>
+        </div>
+
+        <div class="weekly-chart__value"><%= data[:total_ml] %>ml</div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="dashboard-section">
   <h2 class="section-title">クイックメニュー</h2>
 
   <div class="quick-actions">


### PR DESCRIPTION
## 概要
ダッシュボードに直近7日間の飲酒量グラフを追加しました。

## 変更内容
- 日ごとの飲酒量を集計
- 記録がない日は0mlとして表示
- ダッシュボードに週間飲酒量グラフを追加

## 確認内容
- グラフが正常に表示されること
- 飲酒記録がグラフに反映されること
- Railsテストがすべて成功すること
