### PR TITLE
ダッシュボードのレスポンシブ表示を改善

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1024,3 +1024,71 @@
   font-size: 14px;
   font-weight: 600;
 }
+
+.dashboard-section {
+  margin-top: 32px;
+}
+
+.dashboard-section:first-child {
+  margin-top: 0;
+}
+
+.section-title {
+  margin: 0 0 16px;
+  font-size: 22px;
+}
+
+.summary-cards {
+  align-items: stretch;
+}
+
+.summary-card {
+  min-height: 110px;
+}
+
+.quick-actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.quick-actions .btn {
+  justify-content: center;
+  text-align: center;
+}
+
+.weekly-chart {
+  padding: 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+}
+
+@media (max-width: 768px) {
+  .section-title {
+    font-size: 20px;
+  }
+
+  .summary-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .quick-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .weekly-chart {
+    padding: 16px;
+  }
+
+  .weekly-chart__row {
+    grid-template-columns: 44px 1fr 56px;
+    gap: 8px;
+  }
+
+  .weekly-chart__label,
+  .weekly-chart__value {
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## 概要

ダッシュボードのレスポンシブ表示を改善しました。

## 変更内容

- ダッシュボード各セクションの余白を調整
- サマリーカードの表示を調整
- クイックメニューを画面幅に応じて見やすく表示
- 週間飲酒量グラフがスマホ幅でも崩れないように調整

## 確認内容

- PC表示でダッシュボードが崩れていないこと
- スマホ幅でサマリーカードが1列表示になること
- クイックメニューがスマホ幅で見やすく表示されること
- 週間飲酒量グラフが横にはみ出さないこと