### PR TITLE
Ransackを用いた在庫検索機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "bootsnap", require: false
 
 gem "devise"
 
+gem "ransack"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -362,6 +366,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.0)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails
@@ -464,6 +469,7 @@ CHECKSUMS
   railties (7.2.3.1) sha256=aea3393ee10243ceedcbeccb45458a0d58b524b6d21bf32eff8b93853baae15a
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1092,3 +1092,24 @@
     font-size: 13px;
   }
 }
+
+.search-box {
+  margin: 20px 0 24px;
+  padding: 20px;
+  border: 1px solid #e5e5e5;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
+}
+
+.search-box__fields {
+  display: grid;
+  grid-template-columns: 1fr 220px;
+  gap: 16px;
+}
+
+@media (max-width: 768px) {
+  .search-box__fields {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -3,7 +3,9 @@ class DrinksController < ApplicationController
   before_action :set_drink, only: %i[edit update destroy]
 
   def index
-    @drinks = current_user.drinks.order(created_at: :desc)
+    @q = Drink.where(user: current_user).ransack(params[:q])
+    @drinks = @q.result.order(created_at: :desc)
+
     @suggested_drink = current_user.drinks.where("stock_ml > 0").order("RANDOM()").first
   end
 

--- a/app/models/drink.rb
+++ b/app/models/drink.rb
@@ -9,6 +9,14 @@ class Drink < ApplicationRecord
                    uniqueness: { scope: :user_id, case_sensitive: false }
   validates :stock_ml, numericality: { greater_than_or_equal_to: 0 }
 
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name stock_ml created_at updated_at user_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[drink_records drink_logs user]
+  end
+
   private
 
   def normalize_name

--- a/app/views/drinks/index.html.erb
+++ b/app/views/drinks/index.html.erb
@@ -5,6 +5,30 @@
   <%= link_to "＋ お酒を登録する", new_drink_path, class: "btn btn--primary" %>
 </div>
 
+<div class="search-box">
+  <%= search_form_for @q, url: drinks_path, method: :get do |f| %>
+    <div class="search-box__fields">
+      <div class="field">
+        <%= f.label :name_cont, "お酒の名前", class: "field__label" %>
+        <%= f.search_field :name_cont, class: "field__input", placeholder: "例: 山崎" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :stock_ml_gt, "在庫状態", class: "field__label" %>
+        <%= f.select :stock_ml_gt,
+            [["すべて", ""], ["在庫あり", 0]],
+            {},
+            class: "field__input" %>
+      </div>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "検索", class: "btn btn--primary" %>
+      <%= link_to "リセット", drinks_path, class: "btn" %>
+    </div>
+  <% end %>
+</div>
+
 <% if @suggested_drink.present? %>
   <div class="suggestion-banner">
     <div class="suggestion-banner__content">


### PR DESCRIPTION
## 概要

Ransackを用いて、在庫一覧ページに検索機能を追加しました。

## 変更内容

- Ransackを導入
- 在庫一覧でお酒の名前を検索できるように変更
- 在庫ありのお酒で絞り込みできるように変更
- 検索条件をリセットできるリンクを追加
- Ransackで検索可能な属性・関連をDrinkモデルに定義
- 検索フォームのスタイルを追加

## 確認内容

- お酒の名前で検索できること
- 在庫ありで絞り込みできること
- リセットで全件表示に戻ること
- 他ユーザーのお酒が検索結果に含まれないこと