### PR TITLE
在庫検索にオートコンプリートを追加

### DIFF
--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -6,6 +6,8 @@ class DrinksController < ApplicationController
     @q = Drink.where(user: current_user).ransack(params[:q])
     @drinks = @q.result.order(created_at: :desc)
 
+    @drink_name_options = current_user.drinks.order(:name).pluck(:name)
+
     @suggested_drink = current_user.drinks.where("stock_ml > 0").order("RANDOM()").first
   end
 

--- a/app/views/drinks/index.html.erb
+++ b/app/views/drinks/index.html.erb
@@ -10,7 +10,16 @@
     <div class="search-box__fields">
       <div class="field">
         <%= f.label :name_cont, "お酒の名前", class: "field__label" %>
-        <%= f.search_field :name_cont, class: "field__input", placeholder: "例: 山崎" %>
+        <%= f.search_field :name_cont,
+            class: "field__input",
+            placeholder: "例: 山崎",
+            list: "drink-name-options" %>
+
+        <datalist id="drink-name-options">
+          <% @drink_name_options.each do |drink_name| %>
+            <option value="<%= drink_name %>"></option>
+          <% end %>
+        </datalist>
       </div>
 
       <div class="field">


### PR DESCRIPTION
## 概要

在庫一覧の検索フォームにオートコンプリートを追加しました。

## 変更内容

- 登録済みのお酒名を検索候補として表示
- お酒の名前検索欄に `datalist` を追加
- ログイン中のユーザーが登録したお酒のみ候補に表示
- 既存のRansack検索と組み合わせて検索できるように変更

## 確認内容

- お酒の名前検索欄に文字を入力すると候補が表示されること
- 候補を選択して検索できること
- 検索結果が正しく絞り込まれること
- 在庫あり検索・リセットが今まで通り動作すること