### PR TITLE
メール通知機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,9 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    devise_parameter_sanitizer.permit(
+      :account_update,
+      keys: [ :name, :drinking_reminder_email_enabled, :recommended_drink_email_enabled ]
+    )
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,20 @@
+class NotificationMailer < ApplicationMailer
+  def drinking_reminder(user)
+    @user = user
+
+    mail(
+      to: @user.email,
+      subject: "【DrinkStock】飲酒記録をつけませんか？"
+    )
+  end
+
+  def recommended_drink(user, drink)
+    @user = user
+    @drink = drink
+
+    mail(
+      to: @user.email,
+      subject: "【DrinkStock】今日のおすすめのお酒"
+    )
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,6 +15,22 @@
       <%= f.email_field :email, autocomplete: "email", class: "field__input" %>
     </div>
 
+    <div class="field">
+      <%= f.label :drinking_reminder_email_enabled, class: "field__label" do %>
+        <%= f.check_box :drinking_reminder_email_enabled %>
+        飲酒記録リマインドメールを受け取る
+      <% end %>
+      <p class="help">飲み忘れ・記録忘れを防ぐためのメールを受け取れます。</p>
+    </div>
+
+    <div class="field">
+      <%= f.label :recommended_drink_email_enabled, class: "field__label" do %>
+        <%= f.check_box :recommended_drink_email_enabled %>
+        おすすめのお酒メールを受け取る
+      <% end %>
+      <p class="help">在庫があるお酒の中から、おすすめのお酒をメールで受け取れます。</p>
+    </div>
+
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p class="help">現在確認待ちのメールアドレス: <%= resource.unconfirmed_email %></p>
     <% end %>

--- a/app/views/notification_mailer/drinking_reminder.html.erb
+++ b/app/views/notification_mailer/drinking_reminder.html.erb
@@ -1,0 +1,10 @@
+<p><%= @user.name.presence || "DrinkStockユーザー" %>さん</p>
+
+<p>最近の飲酒記録をつけませんか？</p>
+
+<p>
+  飲んだお酒を記録すると、在庫も自動で更新されます。<br>
+  今日飲んだお酒があれば、DrinkStockに記録してみましょう。
+</p>
+
+<p>DrinkStock</p>

--- a/app/views/notification_mailer/drinking_reminder.text.erb
+++ b/app/views/notification_mailer/drinking_reminder.text.erb
@@ -1,0 +1,8 @@
+<%= @user.name.presence || "DrinkStockユーザー" %>さん
+
+最近の飲酒記録をつけませんか？
+
+飲んだお酒を記録すると、在庫も自動で更新されます。
+今日飲んだお酒があれば、DrinkStockに記録してみましょう。
+
+DrinkStock

--- a/app/views/notification_mailer/recommended_drink.html.erb
+++ b/app/views/notification_mailer/recommended_drink.html.erb
@@ -1,0 +1,10 @@
+<p><%= @user.name.presence || "DrinkStockユーザー" %>さん</p>
+
+<p>今日のおすすめのお酒は「<strong><%= @drink.name %></strong>」です。</p>
+
+<p>
+  在庫があるお酒の中から選びました。<br>
+  飲んだら記録して、在庫も更新しましょう。
+</p>
+
+<p>DrinkStock</p>

--- a/app/views/notification_mailer/recommended_drink.text.erb
+++ b/app/views/notification_mailer/recommended_drink.text.erb
@@ -1,0 +1,8 @@
+<%= @user.name.presence || "DrinkStockユーザー" %>さん
+
+今日のおすすめのお酒は「<%= @drink.name %>」です。
+
+在庫があるお酒の中から選びました。
+飲んだら記録して、在庫も更新しましょう。
+
+DrinkStock

--- a/db/migrate/20260717120748_add_email_notification_enabled_to_users.rb
+++ b/db/migrate/20260717120748_add_email_notification_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationEnabledToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :email_notification_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20260717170058_add_notification_settings_to_users.rb
+++ b/db/migrate/20260717170058_add_notification_settings_to_users.rb
@@ -1,0 +1,6 @@
+class AddNotificationSettingsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :users, :email_notification_enabled, :drinking_reminder_email_enabled
+    add_column :users, :recommended_drink_email_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_08_104554) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_17_170058) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_08_104554) do
     t.string "name"
     t.string "provider"
     t.string "uid"
+    t.boolean "drinking_reminder_email_enabled", default: true, null: false
+    t.boolean "recommended_drink_email_enabled", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/notification_mailer.rake
+++ b/lib/tasks/notification_mailer.rake
@@ -1,0 +1,24 @@
+namespace :notification_mailer do
+    desc "飲酒記録リマインドメールを送信"
+    task send_drinking_reminders: :environment do
+      User.where(drinking_reminder_email_enabled: true).find_each do |user|
+        puts "Send drinking reminder to #{user.email}"
+        NotificationMailer.drinking_reminder(user).deliver_now
+      end
+    end
+
+    desc "おすすめのお酒メールを送信"
+    task send_recommended_drinks: :environment do
+      User.where(recommended_drink_email_enabled: true).find_each do |user|
+        drink = user.drinks.where("stock_ml > 0").order("RANDOM()").first
+
+        if drink.blank?
+          puts "Skip #{user.email}: 在庫があるお酒がありません"
+          next
+        end
+
+        puts "Send recommended drink to #{user.email}: #{drink.name}"
+        NotificationMailer.recommended_drink(user, drink).deliver_now
+      end
+    end
+  end

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class NotificationMailerTest < ActionMailer::TestCase
+  test "drinking_reminder" do
+    user = User.create!(
+      email: "mail_test@example.com",
+      password: "password"
+    )
+
+    mail = NotificationMailer.drinking_reminder(user)
+
+    assert_equal "【DrinkStock】飲酒記録をつけませんか？", mail.subject
+    assert_equal [ "mail_test@example.com" ], mail.to
+    assert_equal [ "from@example.com" ], mail.from
+    assert_match "最近の飲酒記録をつけませんか？", mail.text_part.body.decoded
+  end
+
+  test "recommended_drink" do
+    user = User.create!(
+      email: "recommended_test@example.com",
+      password: "password"
+    )
+
+    drink = Drink.create!(
+      user: user,
+      name: "ラフロイグ",
+      stock_ml: 700
+    )
+
+    mail = NotificationMailer.recommended_drink(user, drink)
+
+    assert_equal "【DrinkStock】今日のおすすめのお酒", mail.subject
+    assert_equal [ "recommended_test@example.com" ], mail.to
+    assert_equal [ "from@example.com" ], mail.from
+    assert_match "ラフロイグ", mail.text_part.body.decoded
+  end
+end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,12 @@
+# Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
+class NotificationMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/drinking_reminder
+  def drinking_reminder
+    NotificationMailer.drinking_reminder
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/recommended_drink
+  def recommended_drink
+    NotificationMailer.recommended_drink
+  end
+end


### PR DESCRIPTION
## 概要

メール通知機能を追加しました。

## 変更内容

- ユーザーごとの通知設定を追加
  - 飲酒記録リマインドメール
  - おすすめのお酒メール
- アカウント編集画面で通知ON/OFFを変更できるようにしました
- NotificationMailerを追加しました
- 飲酒記録リマインドメールを追加しました
- おすすめのお酒メールを追加しました
- 通知ONのユーザーにメールを送信するrakeタスクを追加しました
- 在庫があるお酒がない場合はおすすめメールをスキップするようにしました
- Mailerのテストを修正・追加しました
- 
## 補足

- 今回のPRでは、メール通知の送信処理と通知設定を追加しました。
- 定期的な自動送信設定は別Iで対応予定です。