### PR TITLE
送信元メールアドレスを環境変数で設定

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "from@example.com")
   layout "mailer"
 end


### PR DESCRIPTION
## 概要

送信元メールアドレスを環境変数 `MAIL_FROM` から取得するように変更しました。

## 変更内容

- `ApplicationMailer` の `default from` を環境変数対応に変更
- 本番環境では `noreply@drink-stock.com` を送信元として使用できるようにしました
