### PR TITLE
Deviseの送信元メールアドレスを環境変数で設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "onboarding@resend.dev"
+  config.mailer_sender = ENV.fetch("MAIL_FROM", "from@example.com")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要

Deviseのメール送信元を環境変数 `MAIL_FROM` から取得するように変更しました。

## 変更内容

- `config.mailer_sender` を `ENV.fetch("MAIL_FROM", "from@example.com")` に変更
- 本番環境でパスワードリセットメールの送信元に `noreply@drink-stock.com` を使用できるようにしました
