### PR TITLE
パスワード再設定メールの件名を日本語化

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -100,6 +100,10 @@ ja:
       updated: "パスワードを変更しました。"
       updated_not_active: "パスワードを変更しました。"
 
+    mailer:
+      reset_password_instructions:
+        subject: "【DrinkStock】パスワード再設定のご案内"
+
     omniauth_callbacks:
       success: "%{kind}アカウントでログインしました。"
       failure: "%{kind}アカウントでのログインに失敗しました。"


### PR DESCRIPTION
## 概要

パスワード再設定メールの件名を日本語に変更しました。

## 変更内容

- Deviseのパスワード再設定メール件名を設定
- 件名を「【DrinkStock】パスワード再設定のご案内」に変更
