### PR TITLE
パスワード再設定メール本文を日本語化

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,19 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> さん</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>DrinkStockをご利用いただきありがとうございます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>
+  パスワード再設定のリクエストを受け付けました。<br>
+  以下のリンクから、新しいパスワードを設定してください。
+</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>
+  <%= link_to "パスワードを再設定する", edit_password_url(@resource, reset_password_token: @token) %>
+</p>
+
+<p>
+  このメールに心当たりがない場合は、このメールを破棄してください。<br>
+  上記のリンクから新しいパスワードを設定するまで、パスワードは変更されません。
+</p>
+
+<p>DrinkStock</p>


### PR DESCRIPTION
## 概要

パスワード再設定メールの本文を日本語に変更しました。

## 変更内容

- Deviseのパスワード再設定メール本文を日本語化
- メール本文をDrinkStock向けの自然な文言に変更