### PR TITLE
管理者ダッシュボードを追加

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,17 @@
+class Admin::DashboardController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  def index
+    @users_count = User.count
+    @drinks_count = Drink.count
+    @drink_records_count = DrinkRecord.count
+    @drink_logs_count = DrinkLog.count
+  end
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+  end
+end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -1,0 +1,2 @@
+module Admin::DashboardHelper
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,8 @@
+<h1>管理者画面</h1>
+
+<div>
+  <p>ユーザー数：<%= @users_count %></p>
+  <p>お酒登録数：<%= @drinks_count %></p>
+  <p>飲酒記録数：<%= @drink_records_count %></p>
+  <p>お酒ログ数：<%= @drink_logs_count %></p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    get "dashboard/index"
+  end
   get "dashboard/index"
   get "drink_logs/index"
   get "drink_logs/new"
@@ -31,4 +34,8 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   root to: "pages#home"
+
+  namespace :admin do
+    root "dashboard#index"
+  end
 end

--- a/db/migrate/20260803081701_add_admin_to_users.rb
+++ b/db/migrate/20260803081701_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_17_170058) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_03_081701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_17_170058) do
     t.string "uid"
     t.boolean "drinking_reminder_email_enabled", default: true, null: false
     t.boolean "recommended_drink_email_enabled", default: true, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "redirects when not logged in" do
+    get admin_root_url
+
+    assert_response :redirect
+    assert_redirected_to new_user_session_path
+  end
+
+  test "redirects when logged in user is not admin" do
+    sign_in users(:one)
+
+    get admin_root_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test "should get index when logged in user is admin" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_root_url
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

管理者ユーザーのみアクセスできる管理者ダッシュボードを追加しました。

## 変更内容

- usersテーブルにadminカラムを追加
- /admin のルーティングを追加
- Admin::DashboardControllerを追加
- 管理者画面でユーザー数・お酒登録数・飲酒記録数・お酒ログ数を表示
- 未ログイン・一般ユーザー・管理者ユーザーのアクセステストを追加