### PR TITLE
管理者用ユーザー一覧を追加

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,14 @@
+class Admin::UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  def index
+    @users = User.order(created_at: :desc)
+  end
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+  end
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,31 @@
+<h1>ユーザー一覧</h1>
+
+<p><%= link_to "管理者画面へ戻る", admin_root_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>名前</th>
+      <th>メールアドレス</th>
+      <th>管理者</th>
+      <th>飲酒記録リマインド</th>
+      <th>おすすめメール</th>
+      <th>登録日時</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.id %></td>
+        <td><%= user.name.presence || "-" %></td>
+        <td><%= user.email %></td>
+        <td><%= user.admin? ? "はい" : "いいえ" %></td>
+        <td><%= user.drinking_reminder_email_enabled? ? "ON" : "OFF" %></td>
+        <td><%= user.recommended_drink_email_enabled? ? "ON" : "OFF" %></td>
+        <td><%= user.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  namespace :admin do
-    get "dashboard/index"
-  end
   get "dashboard/index"
   get "drink_logs/index"
   get "drink_logs/new"
@@ -37,5 +34,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     root "dashboard#index"
+    resources :users, only: [ :index ]
   end
 end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "redirects when not logged in" do
+    get admin_users_url
+
+    assert_response :redirect
+    assert_redirected_to new_user_session_path
+  end
+
+  test "redirects when logged in user is not admin" do
+    sign_in users(:one)
+
+    get admin_users_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test "should get index when logged in user is admin" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_users_url
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

管理者画面にユーザー一覧ページを追加しました。

## 変更内容

- /admin/users のルーティングを追加
- Admin::UsersController を追加
- 管理者のみユーザー一覧を閲覧できるように設定
- ユーザーの名前・メールアドレス・管理者権限・通知設定・登録日時を表示
- 管理者用ユーザー一覧のアクセステストを追加