### PR TITLE
管理者用在庫一覧を追加

### DIFF
--- a/app/controllers/admin/drinks_controller.rb
+++ b/app/controllers/admin/drinks_controller.rb
@@ -1,0 +1,14 @@
+class Admin::DrinksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  def index
+    @drinks = Drink.includes(:user).order(created_at: :desc)
+  end
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+  end
+end

--- a/app/helpers/admin/drinks_helper.rb
+++ b/app/helpers/admin/drinks_helper.rb
@@ -1,0 +1,2 @@
+module Admin::DrinksHelper
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -6,3 +6,8 @@
   <p>飲酒記録数：<%= @drink_records_count %></p>
   <p>お酒ログ数：<%= @drink_logs_count %></p>
 </div>
+
+<div>
+  <p><%= link_to "ユーザー一覧", admin_users_path %></p>
+  <p><%= link_to "在庫一覧", admin_drinks_path %></p>
+</div>

--- a/app/views/admin/drinks/index.html.erb
+++ b/app/views/admin/drinks/index.html.erb
@@ -1,0 +1,29 @@
+<h1>在庫一覧</h1>
+
+<p><%= link_to "管理者画面へ戻る", admin_root_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>お酒名</th>
+      <th>在庫量</th>
+      <th>ユーザー名</th>
+      <th>メールアドレス</th>
+      <th>登録日時</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @drinks.each do |drink| %>
+      <tr>
+        <td><%= drink.id %></td>
+        <td><%= drink.name %></td>
+        <td><%= drink.stock_ml %>ml</td>
+        <td><%= drink.user.name.presence || "-" %></td>
+        <td><%= drink.user.email %></td>
+        <td><%= drink.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,5 +35,6 @@ Rails.application.routes.draw do
   namespace :admin do
     root "dashboard#index"
     resources :users, only: [ :index ]
+    resources :drinks, only: [ :index ]
   end
 end

--- a/test/controllers/admin/drinks_controller_test.rb
+++ b/test/controllers/admin/drinks_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::DrinksControllerTest < ActionDispatch::IntegrationTest
+  test "redirects when not logged in" do
+    get admin_drinks_url
+
+    assert_response :redirect
+    assert_redirected_to new_user_session_path
+  end
+
+  test "redirects when logged in user is not admin" do
+    sign_in users(:one)
+
+    get admin_drinks_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test "should get index when logged in user is admin" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_drinks_url
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

管理者画面に在庫一覧ページを追加しました。

## 変更内容

- /admin/drinks のルーティングを追加
- Admin::DrinksController を追加
- 管理者のみ在庫一覧を閲覧できるように設定
- 全ユーザーのお酒名・在庫量・ユーザー情報・登録日時を一覧表示
- 管理者トップから在庫一覧へのリンクを追加
- 管理者用在庫一覧のアクセステストを追加
