### PR TITLE
管理者用飲酒記録一覧を追加

### DIFF
--- a/app/controllers/admin/drink_records_controller.rb
+++ b/app/controllers/admin/drink_records_controller.rb
@@ -1,0 +1,14 @@
+class Admin::DrinkRecordsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  def index
+    @drink_records = DrinkRecord.includes(:user, :drink).order(consumed_at: :desc)
+  end
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+  end
+end

--- a/app/helpers/admin/drink_records_helper.rb
+++ b/app/helpers/admin/drink_records_helper.rb
@@ -1,0 +1,2 @@
+module Admin::DrinkRecordsHelper
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -10,4 +10,5 @@
 <div>
   <p><%= link_to "ユーザー一覧", admin_users_path %></p>
   <p><%= link_to "在庫一覧", admin_drinks_path %></p>
+  <p><%= link_to "飲酒記録一覧", admin_drink_records_path %></p>
 </div>

--- a/app/views/admin/drink_records/index.html.erb
+++ b/app/views/admin/drink_records/index.html.erb
@@ -1,0 +1,31 @@
+<h1>飲酒記録一覧</h1>
+
+<p><%= link_to "管理者画面へ戻る", admin_root_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>お酒名</th>
+      <th>飲酒量</th>
+      <th>飲酒日時</th>
+      <th>ユーザー名</th>
+      <th>メールアドレス</th>
+      <th>登録日時</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @drink_records.each do |drink_record| %>
+      <tr>
+        <td><%= drink_record.id %></td>
+        <td><%= drink_record.drink.name %></td>
+        <td><%= drink_record.consumed_ml %>ml</td>
+        <td><%= drink_record.consumed_at.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= drink_record.user.name.presence || "-" %></td>
+        <td><%= drink_record.user.email %></td>
+        <td><%= drink_record.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,5 +36,6 @@ Rails.application.routes.draw do
     root "dashboard#index"
     resources :users, only: [ :index ]
     resources :drinks, only: [ :index ]
+    resources :drink_records, only: [ :index ]
   end
 end

--- a/test/controllers/admin/drink_records_controller_test.rb
+++ b/test/controllers/admin/drink_records_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::DrinkRecordsControllerTest < ActionDispatch::IntegrationTest
+  test "redirects when not logged in" do
+    get admin_drink_records_url
+
+    assert_response :redirect
+    assert_redirected_to new_user_session_path
+  end
+
+  test "redirects when logged in user is not admin" do
+    sign_in users(:one)
+
+    get admin_drink_records_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test "should get index when logged in user is admin" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_drink_records_url
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

管理者画面に飲酒記録一覧ページを追加しました。

## 変更内容

- /admin/drink_records のルーティングを追加
- Admin::DrinkRecordsController を追加
- 管理者のみ飲酒記録一覧を閲覧できるように設定
- 全ユーザーの飲酒記録・飲酒量・飲酒日時・ユーザー情報を一覧表示
- 管理者トップから飲酒記録一覧へのリンクを追加
- 管理者用飲酒記録一覧のアクセステストを追加