### PR TITLE
管理者用お酒ログ一覧を追加

### DIFF
--- a/app/controllers/admin/drink_logs_controller.rb
+++ b/app/controllers/admin/drink_logs_controller.rb
@@ -1,0 +1,14 @@
+class Admin::DrinkLogsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  def index
+    @drink_logs = DrinkLog.includes(:user, :drink).order(logged_at: :desc)
+  end
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+  end
+end

--- a/app/helpers/admin/drink_logs_helper.rb
+++ b/app/helpers/admin/drink_logs_helper.rb
@@ -1,0 +1,2 @@
+module Admin::DrinkLogsHelper
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -11,4 +11,5 @@
   <p><%= link_to "ユーザー一覧", admin_users_path %></p>
   <p><%= link_to "在庫一覧", admin_drinks_path %></p>
   <p><%= link_to "飲酒記録一覧", admin_drink_records_path %></p>
+  <p><%= link_to "お酒ログ一覧", admin_drink_logs_path %></p>
 </div>

--- a/app/views/admin/drink_logs/index.html.erb
+++ b/app/views/admin/drink_logs/index.html.erb
@@ -1,0 +1,33 @@
+<h1>お酒ログ一覧</h1>
+
+<p><%= link_to "管理者画面へ戻る", admin_root_path %></p>
+
+<table>
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>お酒名</th>
+      <th>メモ</th>
+      <th>評価</th>
+      <th>ログ日時</th>
+      <th>ユーザー名</th>
+      <th>メールアドレス</th>
+      <th>登録日時</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @drink_logs.each do |drink_log| %>
+      <tr>
+        <td><%= drink_log.id %></td>
+        <td><%= drink_log.drink_name.presence || drink_log.drink&.name || "-" %></td>
+        <td><%= drink_log.memo.presence || "-" %></td>
+        <td><%= drink_log.rating.presence || "-" %></td>
+        <td><%= drink_log.logged_at.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= drink_log.user.name.presence || "-" %></td>
+        <td><%= drink_log.user.email %></td>
+        <td><%= drink_log.created_at.strftime("%Y/%m/%d %H:%M") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,5 +37,6 @@ Rails.application.routes.draw do
     resources :users, only: [ :index ]
     resources :drinks, only: [ :index ]
     resources :drink_records, only: [ :index ]
+    resources :drink_logs, only: [ :index ]
   end
 end

--- a/test/controllers/admin/drink_logs_controller_test.rb
+++ b/test/controllers/admin/drink_logs_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::DrinkLogsControllerTest < ActionDispatch::IntegrationTest
+  test "redirects when not logged in" do
+    get admin_drink_logs_url
+
+    assert_response :redirect
+    assert_redirected_to new_user_session_path
+  end
+
+  test "redirects when logged in user is not admin" do
+    sign_in users(:one)
+
+    get admin_drink_logs_url
+
+    assert_response :redirect
+    assert_redirected_to root_path
+  end
+
+  test "should get index when logged in user is admin" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_drink_logs_url
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

管理者画面にお酒ログ一覧ページを追加しました。

## 変更内容

- /admin/drink_logs のルーティングを追加
- Admin::DrinkLogsController を追加
- 管理者のみお酒ログ一覧を閲覧できるように設定
- 全ユーザーのお酒ログ・メモ・評価・ログ日時・ユーザー情報を一覧表示
- 管理者トップからお酒ログ一覧へのリンクを追加
- 管理者用お酒ログ一覧のアクセステストを追加
