### PR TITLE
管理者コントローラーの共通処理を整理

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,10 @@
+class Admin::BaseController < ApplicationController
+    before_action :authenticate_user!
+    before_action :require_admin
+
+    private
+
+    def require_admin
+      redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
+    end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,17 +1,8 @@
-class Admin::DashboardController < ApplicationController
-  before_action :authenticate_user!
-  before_action :require_admin
-
+class Admin::DashboardController < Admin::BaseController
   def index
     @users_count = User.count
     @drinks_count = Drink.count
     @drink_records_count = DrinkRecord.count
     @drink_logs_count = DrinkLog.count
-  end
-
-  private
-
-  def require_admin
-    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
   end
 end

--- a/app/controllers/admin/drink_logs_controller.rb
+++ b/app/controllers/admin/drink_logs_controller.rb
@@ -1,14 +1,5 @@
-class Admin::DrinkLogsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :require_admin
-
+class Admin::DrinkLogsController < Admin::BaseController
   def index
     @drink_logs = DrinkLog.includes(:user, :drink).order(logged_at: :desc)
-  end
-
-  private
-
-  def require_admin
-    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
   end
 end

--- a/app/controllers/admin/drink_records_controller.rb
+++ b/app/controllers/admin/drink_records_controller.rb
@@ -1,14 +1,5 @@
-class Admin::DrinkRecordsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :require_admin
-
+class Admin::DrinkRecordsController < Admin::BaseController
   def index
     @drink_records = DrinkRecord.includes(:user, :drink).order(consumed_at: :desc)
-  end
-
-  private
-
-  def require_admin
-    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
   end
 end

--- a/app/controllers/admin/drinks_controller.rb
+++ b/app/controllers/admin/drinks_controller.rb
@@ -1,14 +1,5 @@
-class Admin::DrinksController < ApplicationController
-  before_action :authenticate_user!
-  before_action :require_admin
-
+class Admin::DrinksController < Admin::BaseController
   def index
     @drinks = Drink.includes(:user).order(created_at: :desc)
-  end
-
-  private
-
-  def require_admin
-    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,14 +1,5 @@
-class Admin::UsersController < ApplicationController
-  before_action :authenticate_user!
-  before_action :require_admin
-
+class Admin::UsersController < Admin::BaseController
   def index
     @users = User.order(created_at: :desc)
-  end
-
-  private
-
-  def require_admin
-    redirect_to root_path, alert: "管理者のみアクセスできます。" unless current_user.admin?
   end
 end


### PR DESCRIPTION
## 概要

管理者用コントローラーの共通処理を整理しました。

## 変更内容

- Admin::BaseController を追加
- 管理者認証処理を Admin::BaseController に集約
- 各管理者用Controllerを Admin::BaseController 継承に変更
- 重複していた before_action と require_admin を削除
