### PR TITLE
管理者ユーザー一覧に検索機能を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1233,3 +1233,44 @@
 .admin-back-link:hover {
   text-decoration: underline;
 }
+
+.admin-search-form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.admin-search-input {
+  min-width: 280px;
+  padding: 10px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.admin-search-button {
+  padding: 10px 16px;
+  border: none;
+  border-radius: 8px;
+  background: #333;
+  color: #fff;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.admin-search-button:hover {
+  background: #555;
+}
+
+.admin-search-reset {
+  display: inline-block;
+  padding: 10px 12px;
+  color: #333;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+.admin-search-reset:hover {
+  text-decoration: underline;
+}

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,12 @@
 class Admin::UsersController < Admin::BaseController
   def index
     @users = User.order(created_at: :desc)
+
+    if params[:q].present?
+      @users = @users.where(
+        "name ILIKE :q OR email ILIKE :q",
+        q: "%#{params[:q]}%"
+      )
+    end
   end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -6,6 +6,12 @@
 
   <%= link_to "管理者画面へ戻る", admin_root_path, class: "admin-back-link" %>
 
+  <%= form_with url: admin_users_path, method: :get, local: true, class: "admin-search-form" do |form| %>
+    <%= form.text_field :q, value: params[:q], placeholder: "名前・メールアドレスで検索", class: "admin-search-input" %>
+    <%= form.submit "検索", class: "admin-search-button" %>
+    <%= link_to "リセット", admin_users_path, class: "admin-search-reset" %>
+  <% end %>
+
   <div class="admin-table-wrapper">
     <table class="admin-table">
       <thead>

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -27,4 +27,16 @@ class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "admin can search users by email" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    get admin_users_url, params: { q: user.email }
+
+    assert_response :success
+    assert_includes response.body, user.email
+  end
 end


### PR DESCRIPTION
## 概要

管理者用ユーザー一覧に検索機能を追加しました。

## 変更内容

- /admin/users で名前・メールアドレス検索ができるように変更
- 検索フォームを追加
- リセットリンクを追加
- 検索フォームのデザインを追加
- 管理者ユーザー検索のテストを追加
