### PR TITLE
管理者在庫一覧に検索機能を追加

### DIFF
--- a/app/controllers/admin/drinks_controller.rb
+++ b/app/controllers/admin/drinks_controller.rb
@@ -1,5 +1,12 @@
 class Admin::DrinksController < Admin::BaseController
   def index
-    @drinks = Drink.includes(:user).order(created_at: :desc)
+    @drinks = Drink.left_joins(:user).includes(:user).order(created_at: :desc)
+
+    if params[:q].present?
+      @drinks = @drinks.where(
+        "drinks.name ILIKE :q OR users.name ILIKE :q OR users.email ILIKE :q",
+        q: "%#{params[:q]}%"
+      )
+    end
   end
 end

--- a/app/views/admin/drinks/index.html.erb
+++ b/app/views/admin/drinks/index.html.erb
@@ -6,6 +6,12 @@
 
   <%= link_to "管理者画面へ戻る", admin_root_path, class: "admin-back-link" %>
 
+  <%= form_with url: admin_drinks_path, method: :get, local: true, class: "admin-search-form" do |form| %>
+    <%= form.text_field :q, value: params[:q], placeholder: "お酒名・ユーザー名・メールアドレスで検索", class: "admin-search-input" %>
+    <%= form.submit "検索", class: "admin-search-button" %>
+    <%= link_to "リセット", admin_drinks_path, class: "admin-search-reset" %>
+  <% end %>
+
   <div class="admin-table-wrapper">
     <table class="admin-table">
       <thead>

--- a/test/controllers/admin/drinks_controller_test.rb
+++ b/test/controllers/admin/drinks_controller_test.rb
@@ -27,4 +27,18 @@ class Admin::DrinksControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "admin can search drinks by name" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    drink = drinks(:one)
+
+    get admin_drinks_url, params: { q: drink.name }
+
+    assert_response :success
+    assert_includes response.body, drink.name
+  end
 end


### PR DESCRIPTION
## 概要

管理者用在庫一覧に検索機能を追加しました。

## 変更内容

- /admin/drinks でお酒名・ユーザー名・メールアドレス検索ができるように変更
- 検索フォームを追加
- リセットリンクを追加
- 在庫一覧検索のテストを追加
