### PR TITLE
管理者飲酒記録一覧に検索機能を追加

### DIFF
--- a/app/controllers/admin/drink_records_controller.rb
+++ b/app/controllers/admin/drink_records_controller.rb
@@ -1,5 +1,15 @@
 class Admin::DrinkRecordsController < Admin::BaseController
   def index
-    @drink_records = DrinkRecord.includes(:user, :drink).order(consumed_at: :desc)
+    @drink_records = DrinkRecord
+                       .left_joins(:user, :drink)
+                       .includes(:user, :drink)
+                       .order(consumed_at: :desc)
+
+    if params[:q].present?
+      @drink_records = @drink_records.where(
+        "drinks.name ILIKE :q OR users.name ILIKE :q OR users.email ILIKE :q",
+        q: "%#{params[:q]}%"
+      )
+    end
   end
 end

--- a/app/views/admin/drink_records/index.html.erb
+++ b/app/views/admin/drink_records/index.html.erb
@@ -6,6 +6,12 @@
 
   <%= link_to "管理者画面へ戻る", admin_root_path, class: "admin-back-link" %>
 
+  <%= form_with url: admin_drink_records_path, method: :get, local: true, class: "admin-search-form" do |form| %>
+    <%= form.text_field :q, value: params[:q], placeholder: "お酒名・ユーザー名・メールアドレスで検索", class: "admin-search-input" %>
+    <%= form.submit "検索", class: "admin-search-button" %>
+    <%= link_to "リセット", admin_drink_records_path, class: "admin-search-reset" %>
+  <% end %>
+
   <div class="admin-table-wrapper">
     <table class="admin-table">
       <thead>

--- a/test/controllers/admin/drink_records_controller_test.rb
+++ b/test/controllers/admin/drink_records_controller_test.rb
@@ -27,4 +27,18 @@ class Admin::DrinkRecordsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "admin can search drink records by drink name" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    drink_record = drink_records(:one)
+
+    get admin_drink_records_url, params: { q: drink_record.drink.name }
+
+    assert_response :success
+    assert_includes response.body, drink_record.drink.name
+  end
 end


### PR DESCRIPTION
## 概要

管理者用飲酒記録一覧に検索機能を追加しました。

## 変更内容

- /admin/drink_records でお酒名・ユーザー名・メールアドレス検索ができるように変更
- 検索フォームを追加
- リセットリンクを追加
- 飲酒記録一覧検索のテストを追加
