### PR TITLE
管理者お酒ログ一覧に検索機能を追加

### DIFF
--- a/app/controllers/admin/drink_logs_controller.rb
+++ b/app/controllers/admin/drink_logs_controller.rb
@@ -1,5 +1,15 @@
 class Admin::DrinkLogsController < Admin::BaseController
   def index
-    @drink_logs = DrinkLog.includes(:user, :drink).order(logged_at: :desc)
+    @drink_logs = DrinkLog
+                    .left_joins(:user, :drink)
+                    .includes(:user, :drink)
+                    .order(logged_at: :desc)
+
+    if params[:q].present?
+      @drink_logs = @drink_logs.where(
+        "drink_logs.drink_name ILIKE :q OR drinks.name ILIKE :q OR drink_logs.memo ILIKE :q OR users.name ILIKE :q OR users.email ILIKE :q",
+        q: "%#{params[:q]}%"
+      )
+    end
   end
 end

--- a/app/views/admin/drink_logs/index.html.erb
+++ b/app/views/admin/drink_logs/index.html.erb
@@ -6,6 +6,14 @@
 
   <%= link_to "管理者画面へ戻る", admin_root_path, class: "admin-back-link" %>
 
+  <%= link_to "管理者画面へ戻る", admin_root_path, class: "admin-back-link" %>
+
+  <%= form_with url: admin_drink_logs_path, method: :get, local: true, class: "admin-search-form" do |form| %>
+    <%= form.text_field :q, value: params[:q], placeholder: "お酒名・メモ・ユーザー名・メールアドレスで検索", class: "admin-search-input" %>
+    <%= form.submit "検索", class: "admin-search-button" %>
+    <%= link_to "リセット", admin_drink_logs_path, class: "admin-search-reset" %>
+  <% end %>
+
   <div class="admin-table-wrapper">
     <table class="admin-table">
       <thead>

--- a/test/controllers/admin/drink_logs_controller_test.rb
+++ b/test/controllers/admin/drink_logs_controller_test.rb
@@ -27,4 +27,18 @@ class Admin::DrinkLogsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "admin can search drink logs by memo" do
+    user = users(:one)
+    user.update!(admin: true)
+
+    sign_in user
+
+    drink_log = drink_logs(:one)
+
+    get admin_drink_logs_url, params: { q: drink_log.memo }
+
+    assert_response :success
+    assert_includes response.body, drink_log.memo
+  end
 end


### PR DESCRIPTION
## 概要

管理者用お酒ログ一覧に検索機能を追加しました。

## 変更内容

- /admin/drink_logs でお酒名・メモ・ユーザー名・メールアドレス検索ができるように変更
- 検索フォームを追加
- リセットリンクを追加
- お酒ログ一覧検索のテストを追加