### PR TITLE
ヘッダーに管理者画面へのリンクを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,6 +50,11 @@
             <%= link_to "お酒ログ", drink_logs_path, class: "nav__link" %>
             <%= link_to "使い方", guide_path, class: "nav__link" %>
             <%= link_to "アカウント", account_path, class: "nav__link" %>
+
+            <% if current_user.admin? %>
+              <%= link_to "管理者画面", admin_root_path, class: "nav__link" %>
+            <% end %>
+
             <%= link_to "ログアウト",
                                    destroy_user_session_path,
                                    data: { turbo_method: :delete },


### PR DESCRIPTION
## 概要

管理者ユーザーが管理者画面へ移動しやすいように、ヘッダーに管理者画面へのリンクを追加しました。

## 変更内容

- ログイン中かつ管理者ユーザーの場合のみ、ヘッダーに「管理者画面」リンクを表示
- 「管理者画面」リンクから /admin に移動できるように変更
- 一般ユーザーには管理者画面リンクが表示されないことを確認
