### PR TITLE
本番URLを独自ドメインに変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <meta property="og:title" content="DrinkStock">
     <meta property="og:description" content="家にあるお酒の在庫と飲酒記録をまとめて管理できるWebアプリです。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://drink-stock.onrender.com">
+    <meta property="og:url" content="https://drink-stock.com">
     <meta property="og:image" content="<%= image_url('ogp.png') %>">
     <meta property="og:site_name" content="DrinkStock">
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,11 +78,11 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {
-    host: "drink-stock.onrender.com",
+    host: "drink-stock.com",
     protocol: "https"
   }
   config.action_controller.default_url_options = {
-  host: "drink-stock.onrender.com",
+  host: "drink-stock.com",
   protocol: "https"
   }
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
## 概要

本番環境で使用するURLをRenderの初期URLから独自ドメインに変更しました。

## 変更内容

- production.rb の本番ホストを drink-stock.com に変更
- OGP URLを https://drink-stock.com に変更